### PR TITLE
Add --development option for creating iOS Development certificates.

### DIFF
--- a/bin/cert
+++ b/bin/cert
@@ -23,6 +23,7 @@ class CertApplication
     always_trace!
 
     global_option '-u', '--username STRING', 'Your Apple ID username'
+    global_option '--development', 'Create a development certificate instead of a distribution one.'
 
     command :create do |c|
       c.syntax = 'cert create'
@@ -31,7 +32,10 @@ class CertApplication
       c.action do |args, options|
         username(options)
 
-        Cert::CertRunner.run
+        type = FastlaneCore::DeveloperCenter::DISTRIBUTION
+        type = FastlaneCore::DeveloperCenter::DEVELOPMENT if options.development
+
+        Cert::CertRunner.run(type)
 
         installed = Cert::CertChecker.is_installed?ENV["CER_FILE_PATH"]
         raise "Could not find the newly generated certificate installed" unless installed

--- a/lib/cert/cert_runner.rb
+++ b/lib/cert/cert_runner.rb
@@ -1,7 +1,7 @@
 module Cert
   class CertRunner
-    def self.run
-      FastlaneCore::DeveloperCenter.new.run
+    def self.run(type)
+      FastlaneCore::DeveloperCenter.new.run(type)
     end
   end
 end

--- a/lib/cert/developer_center.rb
+++ b/lib/cert/developer_center.rb
@@ -2,28 +2,36 @@ require 'fastlane_core/developer_center/developer_center'
 
 module FastlaneCore
   class DeveloperCenter
-    CERTS_URL = "https://developer.apple.com/account/ios/certificate/certificateList.action"
+    DISTRIBUTION = "Distribution"
+    DEVELOPMENT = "Development"
+
+    CERTS_URL = "https://developer.apple.com/account/ios/certificate/certificateList.action?type=distribution"
+    CERTS_URL_DEV = "https://developer.apple.com/account/ios/certificate/certificateList.action?type=development"
     CREATE_CERT_URL = "https://developer.apple.com/account/ios/certificate/certificateCreate.action"
 
     # This will check if there is at least one of the certificates already installed on the local machine
     # This will store the resulting file name in ENV 'CER_FILE_PATH' and the Cert ID in 'CER_CERTIFICATE_ID'
-    def run
-      file = find_existing_cert
+    def run(type)
+      file = find_existing_cert(type)
       if file
         # We don't need to do anything :)
         ENV["CER_FILE_PATH"] = file
       else
-        create_certificate
+        create_certificate(type)
       end
     rescue => ex
       error_occured(ex)
     end
 
-    def find_existing_cert
-      visit "#{CERTS_URL}?type=distribution"
+    def find_existing_cert(type)
+      if type == DEVELOPMENT
+        visit CERTS_URL_DEV
+      else
+        visit CERTS_URL
+      end
 
       # Download all available certs to check if they are installed using the SHA1 hash
-      certs = code_signing_certificate
+      certs = code_signing_certificate(type)
       certs.each do |current|
         display_id = current['certificateId']
         type_id = current['certificateTypeDisplayId']
@@ -46,14 +54,16 @@ module FastlaneCore
     end
 
     # This will actually create a new certificate
-    def create_certificate
+    def create_certificate(type)
       visit CREATE_CERT_URL
       wait_for_elements("form[name='certificateSave']")
 
       Helper.log.info "Creating a new code signing certificate"
 
       # select certificate type
-      app_store_toggle = first("input#type-iosNoOCSP")
+      toggle_value = 'type-iosNoOCSP'
+      toggle_value = 'type-development' if type == DEVELOPMENT
+      app_store_toggle = first("input##{toggle_value}")
       if !!app_store_toggle['disabled']
         # Limit of certificates already reached
         raise "Could not create another certificate, reached the maximum number of available certificates.".red
@@ -67,7 +77,6 @@ module FastlaneCore
 
       cert_signing_request = Cert::SigningRequest.get_path
       Helper.log.info "Uploading the cert signing request '#{cert_signing_request}'"
-      
 
       wait_for_elements("input[name='upload']").first.set cert_signing_request # upload the cert signing request
       sleep 1
@@ -86,12 +95,12 @@ module FastlaneCore
       # Now download the certificate
       download_button = wait_for_elements(".button.small.blue").first
       url = download_button['href']
-      
+
       path = File.join(TMP_FOLDER, "certificate.cer")
       download_url(url, path)
-      
+
       certificate_id = url.match(/.*displayId=(.*)&type.*/)[1]
-      
+
       ENV["CER_FILE_PATH"] = path
       ENV["CER_CERTIFICATE_ID"] = certificate_id
       Helper.log.info "Successfully downloaded latest .cer file to '#{path}' (#{certificate_id})".green
@@ -117,7 +126,7 @@ module FastlaneCore
         raise "Something went wrong when downloading the certificate" unless data
 
         dataWritten = File.write(output_path, data)
-        
+
         if dataWritten == 0
           raise "Can't write to #{output_path}"
         end
@@ -141,9 +150,12 @@ module FastlaneCore
         # "certificateTypeDisplayId"=>"...",
         # "serialNum"=>"....",
         # "typeString"=>"iOS Distribution"},
-      def code_signing_certificate
-        certs_url = "https://developer.apple.com/account/ios/certificate/certificateList.action?type=distribution"
-        visit certs_url
+      def code_signing_certificate(type)
+        if type == DEVELOPMENT
+          visit CERTS_URL_DEV
+        else
+          visit CERTS_URL
+        end
 
         certificateDataURL = wait_for_variable('certificateDataURL')
         certificateRequestTypes = wait_for_variable('certificateRequestTypes')
@@ -155,16 +167,18 @@ module FastlaneCore
 
         available = []
 
+        certTypeName = 'iOS Distribution'
+        certTypeName = 'iOS Development' if type == DEVELOPMENT
         certs = post_ajax(url)['certRequests']
         certs.each do |current_cert|
-          if current_cert['typeString'] == 'iOS Distribution' 
+          if current_cert['typeString'] == certTypeName
             # The other profiles are push profiles
             # We only care about the distribution profile
             available << current_cert # mostly we only care about the 'certificateId'
           end
         end
 
-        return available        
+        return available
       end
 
       def click_next


### PR DESCRIPTION
### --development

Pass --development to cert to create a new iOS Development certificate.

Verified the creation of new development certificates and redundancy checks against previously created development certificates installed in the current keychain, as well as the continued management of distribution certificates.

@KrauseFx Take a look at the changes and feel free to make suggestions. I've tried to mirror the switches found in sigh for providing a similar option. I'd also like to update fastlane to support this option in the cert action at some point.
