### PR TITLE
Fix character encoding error when writing binary data (certificates)

### DIFF
--- a/lib/cert/developer_center.rb
+++ b/lib/cert/developer_center.rb
@@ -126,7 +126,10 @@ module Cert
 
         raise "Something went wrong when downloading the certificate" unless data
 
-        dataWritten = File.write(output_path, data)
+        # write data to file
+        dataWritten = File.open(output_path, "wb") do |f|
+          f.write(data)
+        end
 
         if dataWritten == 0
           raise "Can't write to #{output_path}"


### PR DESCRIPTION
Currently, files are written in non-binary mode, thus throwing an Encoding::UndefinedConversionError:

```
     Encoding::UndefinedConversionError:
       "\x82" from ASCII-8BIT to UTF-8
```

Fixes:
- Specify binary write mode (wb) when writing downloaded certificates to files in download_url method of developer_center.rb.
