### PR TITLE
Improved output_path behaviour.

### DIFF
--- a/lib/cert/runner.rb
+++ b/lib/cert/runner.rb
@@ -10,7 +10,8 @@ module Cert
     end
 
     def run
-      FileUtils.mkdir_p(Gym.config[:output_path])
+      FileUtils.mkdir_p(Cert.config[:output_path])
+
       FastlaneCore::PrintTable.print_values(config: Cert.config, hide_keys: [], title: "Summary for cert #{Cert::VERSION}")
 
       Helper.log.info "Starting login with user '#{Cert.config[:username]}'"

--- a/lib/cert/runner.rb
+++ b/lib/cert/runner.rb
@@ -1,3 +1,5 @@
+require 'fileutils'
+
 module Cert
   class Runner
     def launch
@@ -8,6 +10,7 @@ module Cert
     end
 
     def run
+      FileUtils.mkdir_p(Gym.config[:output_path])
       FastlaneCore::PrintTable.print_values(config: Cert.config, hide_keys: [], title: "Summary for cert #{Cert::VERSION}")
 
       Helper.log.info "Starting login with user '#{Cert.config[:username]}'"
@@ -74,9 +77,9 @@ module Cert
       end
 
       # Store all that onto the filesystem
-      request_path = File.join(Cert.config[:output_path], 'CertCertificateSigningRequest.certSigningRequest')
+      request_path = File.expand_path(File.join(Cert.config[:output_path], 'CertCertificateSigningRequest.certSigningRequest'))
       File.write(request_path, csr.to_pem)
-      private_key_path = File.join(Cert.config[:output_path], 'private_key.p12')
+      private_key_path = File.expand_path(File.join(Cert.config[:output_path], 'private_key.p12'))
       File.write(private_key_path, pkey)
       cert_path = store_certificate(certificate)
 
@@ -94,7 +97,7 @@ module Cert
     end
 
     def store_certificate(certificate)
-      path = File.join(Cert.config[:output_path], "#{certificate.id}.cer")
+      path = File.expand_path(File.join(Cert.config[:output_path], "#{certificate.id}.cer"))
       raw_data = certificate.download_raw
       File.write(path, raw_data)
       return path

--- a/lib/cert/version.rb
+++ b/lib/cert/version.rb
@@ -1,3 +1,3 @@
 module Cert
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
 end

--- a/lib/cert/version.rb
+++ b/lib/cert/version.rb
@@ -1,3 +1,3 @@
 module Cert
-  VERSION = "1.1.1"
+  VERSION = "1.1.0"
 end

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -12,7 +12,7 @@ describe Cert do
 
       Cert::Runner.new.launch
       expect(ENV["CER_CERTIFICATE_ID"]).to eq("cert_id")
-      expect(ENV["CER_FILE_PATH"]).to eq("./cert_id.cer")
+      expect(ENV["CER_FILE_PATH"]).to eq("#{Dir.pwd}/cert_id.cer")
       File.delete(ENV["CER_FILE_PATH"])
     end
   end


### PR DESCRIPTION
Cert now takes a leave out of Gym's book and creates the output folder if it doesn't exist.

Cert also expands relative paths so it should work from fastlane or the command line. Previously relative paths only worked from the command line.
