### PR TITLE
Force encoding to ASCII-8BIT for the cert

### DIFF
--- a/lib/cert/runner.rb
+++ b/lib/cert/runner.rb
@@ -124,7 +124,7 @@ module Cert
     def store_certificate(certificate)
       path = File.expand_path(File.join(Cert.config[:output_path], "#{certificate.id}.cer"))
       raw_data = certificate.download_raw
-      File.write(path, raw_data)
+      File.write(path, raw_data, encoding: "ASCII-8BIT")
       return path
     end
   end


### PR DESCRIPTION
Sometimes other pieces of code set the global encode.  This causes the cert write to fail because it has to be ASCII-8BIT encoded.