### PR TITLE
https://github.com/fastlane/match/issues/8

### DIFF
--- a/lib/cert/runner.rb
+++ b/lib/cert/runner.rb
@@ -81,8 +81,8 @@ module Cert
     # The kind of certificate we're interested in
     def certificate_type
       cert_type = Spaceship.certificate.production
-      cert_type = Spaceship.certificate.development if Cert.config[:development]
       cert_type = Spaceship.certificate.in_house if Spaceship.client.in_house?
+      cert_type = Spaceship.certificate.development if Cert.config[:development] || (Cert.config[:development] && Spaceship.client.in_house?)
 
       cert_type
     end

--- a/lib/cert/runner.rb
+++ b/lib/cert/runner.rb
@@ -82,7 +82,7 @@ module Cert
     def certificate_type
       cert_type = Spaceship.certificate.production
       cert_type = Spaceship.certificate.in_house if Spaceship.client.in_house?
-      cert_type = Spaceship.certificate.development if Cert.config[:development] || (Cert.config[:development] && Spaceship.client.in_house?)
+      cert_type = Spaceship.certificate.development if Cert.config[:development]
 
       cert_type
     end


### PR DESCRIPTION
add support for enterprise and App Store accounts together.
Match will now correctly generate a development certificate and provisioning profile for
enterprise accounts, even if the reside on the same repo with App Store accounts.
